### PR TITLE
Feat/login

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,9 +1,14 @@
+import java.util.Properties
+
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }
+
+
 
 android {
     namespace = "com.jung.krap"
@@ -28,7 +33,15 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+
+        val properties = Properties().apply {
+            load(rootProject.file("local.properties").inputStream())
+        }
+
+        manifestPlaceholders["kakaoApiKey"] = properties.getProperty("kakaoApiKey")
+
     }
+
 
     buildTypes {
         release {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,6 +25,25 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+
+        <activity
+            android:name="com.kakao.sdk.flutter.AuthCodeCustomTabsActivity"
+            android:exported="true">
+            <intent-filter android:label="flutter_web_auth">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <!-- "kakao${YOUR_NATIVE_APP_KEY}://oauth" 형식의 앱 실행 스킴 설정 -->
+                <!-- 카카오 로그인 Redirect URI -->
+                <data
+                    android:host="oauth"
+                    android:scheme="${kakaoApiKey}" />
+            </intent-filter>
+        </activity>
+
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/lib/common/dto/user_info.dart
+++ b/lib/common/dto/user_info.dart
@@ -1,0 +1,27 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'user_info.g.dart';
+
+@JsonSerializable()
+class UserInfo {
+  UserInfo({
+    required this.userId,
+    required this.email,
+    required this.nickname,
+    required this.profile,
+    required this.bio,
+    required this.kakaoId,
+  });
+
+  final num userId;
+  final String email;
+  final String nickname;
+  final String profile;
+  final String? bio;
+  final num kakaoId;
+
+  factory UserInfo.fromJson(Map<String, dynamic> json) =>
+      _$UserInfoFromJson(json);
+
+  Map<String, dynamic> toJson() => _$UserInfoToJson(this);
+}

--- a/lib/common/styles/button_styles.dart
+++ b/lib/common/styles/button_styles.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class ButtonStyles {
+  static final ButtonStyle kakaoButton = ElevatedButton.styleFrom(
+    padding: EdgeInsets.zero,
+    minimumSize: Size.zero,
+    alignment: Alignment.center,
+    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+    backgroundColor: Colors.transparent,
+    // 이미지 배경 투명 처리
+    shadowColor: Colors.transparent, // 그림자 제거(필요하면)
+  );
+}

--- a/lib/common/styles/text_styles.dart
+++ b/lib/common/styles/text_styles.dart
@@ -50,4 +50,16 @@ class TextStyles {
     fontWeight: FontWeight.w700,
     color: AppColor.AppColors.primary,
   );
+  static TextStyle bold30Black = const TextStyle(
+    fontFamily: 'NotoSans',
+    fontSize: 30,
+    fontWeight: FontWeight.w700,
+    color: AppColor.AppColors.black,
+  );
+  static TextStyle bold30Primary = const TextStyle(
+    fontFamily: 'NotoSans',
+    fontSize: 30,
+    fontWeight: FontWeight.w700,
+    color: AppColor.AppColors.primary,
+  );
 }

--- a/lib/common/widgets/loading_dialog.dart
+++ b/lib/common/widgets/loading_dialog.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class LoadingDialog extends StatelessWidget {
+  const LoadingDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: CircularProgressIndicator());
+  }
+
+  static Future<void> show(BuildContext context) {
+    return showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => const LoadingDialog(),
+    );
+  }
+
+  static void dismiss(BuildContext context) {
+    Navigator.of(context, rootNavigator: true).pop();
+  }
+}

--- a/lib/core/navigation/app_router.dart
+++ b/lib/core/navigation/app_router.dart
@@ -9,4 +9,12 @@ class AppRouter {
   static void goTutorial(BuildContext context) {
     Navigator.pushNamed(context, RoutePaths.tutorial);
   }
+
+  static void goHome(BuildContext context) {
+    Navigator.pushNamed(context, RoutePaths.home);
+  }
+
+  static void replaceHome(BuildContext context) {
+    Navigator.pushReplacementNamed(context, RoutePaths.home);
+  }
 }

--- a/lib/core/navigation/route_paths.dart
+++ b/lib/core/navigation/route_paths.dart
@@ -2,4 +2,5 @@ class RoutePaths {
   static const index = '/index';
   static const login = '/login';
   static const tutorial = '/tutorial';
+  static const home = '/home';
 }

--- a/lib/feature/home/presentation/home_page.dart
+++ b/lib/feature/home/presentation/home_page.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class HomePage extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Text("Home");
+  }
+}

--- a/lib/feature/login/dto/login_request.dart
+++ b/lib/feature/login/dto/login_request.dart
@@ -1,0 +1,16 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'login_request.g.dart';
+
+@JsonSerializable()
+class LoginRequest {
+  @JsonKey(name: 'accesstoken')
+  final String accessToken;
+
+  LoginRequest({required this.accessToken});
+
+  factory LoginRequest.fromJson(Map<String, dynamic> json) =>
+      _$LoginRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$LoginRequestToJson(this);
+}

--- a/lib/feature/login/presentation/pages/login_page.dart
+++ b/lib/feature/login/presentation/pages/login_page.dart
@@ -1,9 +1,72 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:krap/common/dto/user_info.dart';
+import 'package:krap/common/styles/button_styles.dart';
+import 'package:krap/common/styles/text_styles.dart';
+import 'package:krap/common/widgets/loading_dialog.dart';
+import 'package:krap/core/navigation/app_router.dart';
+import 'package:krap/feature/login/provider/login_viewmodel_provider.dart';
 
 class LoginPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Text("Login");
+    final viewModel = ref.read(loginViewModelProvider.notifier);
+
+    ref.listen<AsyncValue<UserInfo?>>(loginViewModelProvider, (prev, next) {
+      next.whenOrNull(
+        loading: () {
+          LoadingDialog.show(context);
+        },
+        data: (userInfo) {
+          LoadingDialog.dismiss(context);
+          AppRouter.replaceHome(context);
+        },
+        error: (err, _) {
+          LoadingDialog.dismiss(context);
+          showDialog(
+            context: context,
+            builder: (_) => AlertDialog(content: Text('에러: $err')),
+          );
+        },
+      );
+    });
+
+    return SafeArea(
+      child: Scaffold(
+        body: Padding(
+          padding: const EdgeInsets.fromLTRB(20, 113, 20, 51),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('일상 속 모든 것을', style: TextStyles.bold30Black),
+              Row(
+                children: [
+                  Text('스', style: TextStyles.bold30Black),
+                  Text('크', style: TextStyles.bold30Primary),
+                  Text('랩,', style: TextStyles.bold30Black),
+                ],
+              ),
+              Row(
+                children: [
+                  Text('크', style: TextStyles.bold30Primary),
+                  Text('크', style: TextStyles.bold30Black),
+                  Text('랩', style: TextStyles.bold30Primary),
+                ],
+              ),
+              Image.asset('assets/images/logo_big.png'),
+              const Spacer(),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: viewModel.getLoginWithKakao,
+                  style: ButtonStyles.kakaoButton,
+                  child: Image.asset('assets/images/icon_kakao.png'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/feature/login/provider/login_viewmodel_provider.dart
+++ b/lib/feature/login/provider/login_viewmodel_provider.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:krap/common/dto/user_info.dart';
+import 'package:krap/common/provider/dio_provider.dart';
+import 'package:krap/feature/login/repository/login_api.dart';
+import 'package:krap/feature/login/repository/login_repository.dart';
+import 'package:krap/feature/login/repository/login_repository_impl.dart';
+import 'package:krap/feature/login/viewmodel/login_viewmodel.dart';
+
+final loginApiProvider = Provider<LoginApi>((ref) {
+  final dio = ref.watch(dioProvider);
+  return LoginApi(dio);
+});
+
+final loginRepositoryProvider = Provider<LoginRepository>((ref) {
+  final loginApi = ref.watch(loginApiProvider);
+  return LoginRepositoryImpl(loginApi);
+});
+
+final loginViewModelProvider = AsyncNotifierProvider<LoginViewModel, UserInfo?>(
+  LoginViewModel.new,
+);

--- a/lib/feature/login/repository/login_api.dart
+++ b/lib/feature/login/repository/login_api.dart
@@ -1,0 +1,14 @@
+import 'package:dio/dio.dart';
+import 'package:krap/common/dto/user_info.dart';
+import 'package:krap/feature/login/dto/login_request.dart';
+import 'package:retrofit/retrofit.dart';
+
+part 'login_api.g.dart';
+
+@RestApi()
+abstract class LoginApi {
+  factory LoginApi(Dio dio) = _LoginApi;
+
+  @POST('/api/auth/kakao-login')
+  Future<UserInfo> getUserInfo(@Body() LoginRequest loginRequest);
+}

--- a/lib/feature/login/repository/login_repository.dart
+++ b/lib/feature/login/repository/login_repository.dart
@@ -1,0 +1,5 @@
+import 'package:krap/common/dto/user_info.dart';
+
+abstract class LoginRepository {
+  Future<UserInfo> getUserInfo(String accessToken);
+}

--- a/lib/feature/login/repository/login_repository_impl.dart
+++ b/lib/feature/login/repository/login_repository_impl.dart
@@ -1,0 +1,16 @@
+import 'package:krap/common/dto/user_info.dart';
+import 'package:krap/feature/login/dto/login_request.dart';
+import 'package:krap/feature/login/repository/login_api.dart';
+import 'package:krap/feature/login/repository/login_repository.dart';
+
+class LoginRepositoryImpl implements LoginRepository {
+  final LoginApi api;
+
+  LoginRepositoryImpl(this.api);
+
+  @override
+  Future<UserInfo> getUserInfo(String accessToken) {
+    final request = LoginRequest(accessToken: accessToken);
+    return api.getUserInfo(request);
+  }
+}

--- a/lib/feature/login/usecase/login_with_kakao_usecase.dart
+++ b/lib/feature/login/usecase/login_with_kakao_usecase.dart
@@ -1,0 +1,38 @@
+import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
+import 'package:krap/core/util/app_logger.dart';
+
+class LoginWithKakaoUsecase {
+  Future<String> loginWithKakao() async {
+    if (await isKakaoTalkInstalled()) {
+      try {
+        // 카카오톡 앱 로그인 시도
+        AppLogger.e('loginWithKakao(), 앱 로그인');
+        OAuthToken token = await UserApi.instance.loginWithKakaoTalk();
+        AppLogger.d('++loginWithKakao() accessToken = ${token.accessToken}');
+        return token.accessToken;
+      } catch (error) {
+        AppLogger.e('++loginWithKakao() error = $error, 웹 로그인');
+        // 카카오톡 로그인 실패 시 웹 로그인 시도 (선택사항)
+        try {
+          OAuthToken token = await UserApi.instance.loginWithKakaoAccount();
+          AppLogger.d('++loginWithKakao() accessToken = ${token.accessToken}');
+          return token.accessToken;
+        } catch (error) {
+          AppLogger.e('++loginWithKakao() error = $error');
+          rethrow;
+        }
+      }
+    } else {
+      try {
+        // 카카오톡 미설치 환경, 바로 웹 로그인 시도
+        AppLogger.e('loginWithKakao(), 카카오 미설치 웹 로그인');
+        OAuthToken token = await UserApi.instance.loginWithKakaoAccount();
+        AppLogger.d('++loginWithKakao() accessToken = ${token.accessToken}');
+        return token.accessToken;
+      } catch (error) {
+        AppLogger.e('++loginWithKakao() error = $error');
+        rethrow;
+      }
+    }
+  }
+}

--- a/lib/feature/login/usecase/save_login_info_usecase.dart
+++ b/lib/feature/login/usecase/save_login_info_usecase.dart
@@ -1,0 +1,12 @@
+import 'package:krap/common/dto/user_info.dart';
+import 'package:krap/feature/login/repository/login_repository.dart';
+
+class SaveLoginedUserInfoUsecase {
+  final LoginRepository repository;
+
+  SaveLoginedUserInfoUsecase(this.repository);
+
+  Future<UserInfo> call(String accessToken) async {
+    return await repository.getUserInfo(accessToken);
+  }
+}

--- a/lib/feature/login/viewmodel/login_viewmodel.dart
+++ b/lib/feature/login/viewmodel/login_viewmodel.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:krap/common/dto/user_info.dart';
+import 'package:krap/core/util/app_logger.dart';
+import 'package:krap/feature/login/provider/login_viewmodel_provider.dart';
+import 'package:krap/feature/login/usecase/login_with_kakao_usecase.dart';
+import 'package:krap/feature/login/usecase/save_login_info_usecase.dart';
+
+class LoginViewModel extends AsyncNotifier<UserInfo?> {
+  late final LoginWithKakaoUsecase loginWithKakao;
+  late final SaveLoginedUserInfoUsecase saveLogin;
+
+  @override
+  FutureOr<UserInfo?> build() {
+    final repo = ref.watch(loginRepositoryProvider);
+    loginWithKakao = LoginWithKakaoUsecase();
+    saveLogin = SaveLoginedUserInfoUsecase(repo);
+    return null;
+  }
+
+  Future<void> getLoginWithKakao() async {
+    try {
+      state = const AsyncValue.loading();
+      final token = await loginWithKakao.loginWithKakao();
+      state = await AsyncValue.guard(() async => saveLoginedUserInfo(token));
+    } catch (error, stack) {
+      state = AsyncValue.error(error, stack);
+      AppLogger.e('++getLoginWithKakao() error = $error');
+    }
+  }
+
+  Future<UserInfo> saveLoginedUserInfo(String token) async {
+    UserInfo userInfo = await saveLogin(token);
+    return userInfo;
+  }
+}

--- a/lib/index_page.dart
+++ b/lib/index_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
 import 'package:krap/core/navigation/app_router.dart';
+import 'package:krap/core/util/app_logger.dart';
 
 class IndexPage extends ConsumerWidget {
   @override
@@ -21,7 +23,10 @@ class IndexPage extends ConsumerWidget {
                     AppRouter.goLogin(context);
                   }),
                 ),
-                Expanded(child: SquareTextButton("", () {})),
+                Expanded(child: SquareTextButton("getKeyHash", () async {
+                  String keyHash = await KakaoSdk.origin;
+                  AppLogger.d('키 해시: $keyHash');
+                })),
                 Expanded(child: SquareTextButton("", () {})),
               ],
             ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:kakao_flutter_sdk/kakao_flutter_sdk.dart';
 import 'package:krap/common/styles/app_colors.dart';
+import 'package:krap/config/config.dart';
 import 'package:krap/core/navigation/route_paths.dart';
 import 'package:krap/feature/Login/presentation/pages/login_page.dart';
+import 'package:krap/feature/home/presentation/home_page.dart';
 import 'package:krap/feature/tutorial/presentation/pages/tutorial_page.dart';
 import 'package:krap/feature/tutorial/provider/tutorial_viewmodel_provider.dart';
 import 'package:krap/index_page.dart';
@@ -12,6 +15,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final prefs = await SharedPreferences.getInstance();
+  KakaoSdk.init(nativeAppKey: Env.kakaoApiKey);
 
   runApp(
     ProviderScope(
@@ -34,6 +38,7 @@ void main() async {
           RoutePaths.index: (context) => IndexPage(),
           RoutePaths.tutorial: (context) => TutorialPage(),
           RoutePaths.login: (context) => LoginPage(),
+          RoutePaths.home: (context) => HomePage(),
         },
       ),
     ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   flutter_riverpod: ^2.4.0
   riverpod_annotation: ^2.3.3
   shared_preferences: ^2.2.2
+  kakao_flutter_sdk: ^1.9.7+3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
##주요 변경 사항 - 로그인 기능 구현
AsyncNotifierProvider를 통한 의존성 주입 및 UserInfo 상태 체크
카카오 로그인을 위한 main, 안드로이드 gradle, manifest 설정, 앱키는 local.properties, config/config.dart에 선언
공통 로딩 다이얼로그 생성
카카오 로그인 usecase와 token을 통한 로그인 usecase로 분리

##변경 목적
카카오 로그인 - sdk를 통한 로그인
token을 통한 로그인 - api를 통한 로그인으로 서로 행위가 다르기 때문에 분리

##기타
dto의 api_response.dart의 역할을 AsyncNotifier를 통한 상태관리가 대신해 추후 삭제 고려 