### PR TITLE
refactor/tutorial

### DIFF
--- a/lib/common/widgets/title_app_bar.dart
+++ b/lib/common/widgets/title_app_bar.dart
@@ -1,15 +1,14 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:krap/common/styles/app_colors.dart';
 import 'package:krap/common/styles/text_styles.dart';
 
-class TitleAppBar extends ConsumerWidget implements PreferredSizeWidget {
+class TitleAppBar extends StatelessWidget implements PreferredSizeWidget {
   const TitleAppBar({super.key, this.actions});
 
   final List<Widget>? actions;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     return AppBar(
       automaticallyImplyLeading: false,
       backgroundColor: AppColors.white,

--- a/lib/feature/tutorial/presentation/pages/tutorial_page.dart
+++ b/lib/feature/tutorial/presentation/pages/tutorial_page.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:krap/common/styles/text_styles.dart';
+import 'package:krap/common/widgets/title_app_bar.dart';
 import 'package:krap/core/navigation/app_router.dart';
+import 'package:krap/feature/tutorial/presentation/widgets/tutorial_app_bar_actions.dart';
 import 'package:krap/feature/tutorial/presentation/widgets/tutorial_indicator.dart';
 import 'package:krap/feature/tutorial/presentation/widgets/tutorial_link.dart';
 import 'package:krap/feature/tutorial/provider/tutorial_viewmodel_provider.dart';
@@ -15,35 +16,15 @@ class TutorialPage extends ConsumerWidget {
     final viewModel = ref.read(tutorialViewModelProvider.notifier);
 
     return Scaffold(
-      appBar: AppBar(
-        title: Row(
-          children: [
-            Image.asset('assets/images/logo_small.png', width: 32, height: 28),
-            Row(
-              children: [
-                Text('크', style: TextStyles.semiBold14Black),
-                Text('크', style: TextStyles.semiBold14Primary),
-                Text('랩', style: TextStyles.semiBold14Black),
-              ],
-            ),
-          ],
-        ),
+      appBar: TitleAppBar(
         actions: [
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 20),
-            child: TextButton(
-              onPressed: () async {
-                await viewModel.completeTutorial();
-                if (context.mounted) {
-                  AppRouter.goLogin(context);
-                }
-              },
-              style: ButtonStyle(
-                overlayColor: WidgetStateProperty.all(Colors.transparent),
-                minimumSize: WidgetStateProperty.all(Size.zero),
-              ),
-              child: Text("건너뛰기", style: TextStyles.medium14Grey),
-            ),
+          TutorialAppBarActions(
+            onBackPress: () async {
+              await viewModel.completeTutorial();
+              if (context.mounted) {
+                AppRouter.goLogin(context);
+              }
+            },
           ),
         ],
       ),

--- a/lib/feature/tutorial/presentation/widgets/tutorial_app_bar_actions.dart
+++ b/lib/feature/tutorial/presentation/widgets/tutorial_app_bar_actions.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:krap/common/styles/text_styles.dart';
+
+class TutorialAppBarActions extends StatelessWidget {
+  TutorialAppBarActions({required this.onBackPress});
+
+  final VoidCallback onBackPress;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: TextButton(
+        onPressed: onBackPress,
+        style: ButtonStyle(
+          overlayColor: WidgetStateProperty.all(Colors.transparent),
+          minimumSize: WidgetStateProperty.all(Size.zero),
+        ),
+        child: Text("건너뛰기", style: TextStyles.medium14Grey),
+      ),
+    );
+  }
+}

--- a/lib/feature/tutorial/presentation/widgets/tutorial_indicator.dart
+++ b/lib/feature/tutorial/presentation/widgets/tutorial_indicator.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:krap/common/styles/app_colors.dart';
 import 'package:krap/common/styles/text_styles.dart';
 
-class TutorialIndicator extends ConsumerWidget {
+class TutorialIndicator extends StatelessWidget {
   const TutorialIndicator({
     super.key,
     required this.currentIndex,
@@ -19,7 +18,7 @@ class TutorialIndicator extends ConsumerWidget {
   final VoidCallback goLogin;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     return Positioned(
       bottom: 40,
       left: 20,

--- a/lib/feature/tutorial/presentation/widgets/tutorial_link.dart
+++ b/lib/feature/tutorial/presentation/widgets/tutorial_link.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/cupertino.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:krap/common/styles/text_styles.dart';
 
-class TutorialLink extends ConsumerWidget {
+class TutorialLink extends StatelessWidget {
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(20, 68, 20, 0),
       child: Column(


### PR DESCRIPTION
##주요 변경 사항
튜토리얼 페이지  ActionBar 모듈화된 공통 위젯으로 변경
ref Provider의존성이 없는 위젯들 StatelessWidget으로 변경

##변경 목적
추후 actionBar의 공통 수정의 경우 한번에 수정될 수 있도록 변경
StatelessWidget으로 변경하여 불필요한 rebuild 방지

##기타
추후 ref를 통한 provide 의존성이 없는 위젯의 경우 Stateless로 변경해야함